### PR TITLE
Add option to electron-pdf commands

### DIFF
--- a/electron_pdf/utils.py
+++ b/electron_pdf/utils.py
@@ -55,13 +55,13 @@ def electron_pdf(input, output_file=None, **kwargs):
     if settings.ELECTRON_WITHOUT_GRAPHICAL_ENV:
         if getattr(settings, 'XVFB_RUN_LOCATION', None):
             subprocess.call(
-                '{} --server-args "-screen 0 1024x768x24" electron-pdf {} {}'.format(
+                """{} --server-args "-screen 0 1024x768x24" electron-pdf {} {} --browserConfig '{{ "webPreferences": {{ "sandbox" : true }} }}'""".format(
                     settings.XVFB_RUN_LOCATION, input.filename, output_file),
                 **subprocess_kwargs)
         else:
-            subprocess.call('xvfb-run --server-args "-screen 0 1024x768x24" electron-pdf {} {}'.format(input.filename, output_file), **subprocess_kwargs)
+            subprocess.call("""xvfb-run --server-args "-screen 0 1024x768x24" electron-pdf {} {} --browserConfig '{{ "webPreferences": {{ "sandbox" : true }} }}'""".format(input.filename, output_file), **subprocess_kwargs)
     else:
-        subprocess.call('electron-pdf {} {}'.format(input.filename, output_file), **subprocess_kwargs)
+        subprocess.call("""electron-pdf {} {} --browserConfig '{{ "webPreferences": {{ "sandbox" : true }} }}'""".format(input.filename, output_file), **subprocess_kwargs)
 
     with open(output_file, 'rb') as f:
         return File(f).read()


### PR DESCRIPTION
Apparently, electron-pdf does only output any result when --browserConfig '{ "webPreferences": { "sandbox" : true } } is passed. See https://github.com/fraserxu/electron-pdf/issues/243